### PR TITLE
新規登録・ログイン後のハンドリング

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,10 +1,10 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def facebook
-    # method in app/models/user.rb
+    # app/models/user.rbにあるメソッドを使用
     @user = User.from_omniauth(request.env["omniauth.auth"])
-
-    sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
-    set_flash_message(:notice, :success, kind: "Facebook") if is_navigational_format?
+    sign_in_and_redirect @user, event: :authentication
+    flash[:success] = @user.sign_in_count == 1 ? (I18n.t 'devise.registrations.signed_up')
+                                               : (I18n.t 'devise.sessions.signed_in')
   end
 
   def failure

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -3,8 +3,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # app/models/user.rbにあるメソッドを使用
     @user = User.from_omniauth(request.env["omniauth.auth"])
     sign_in_and_redirect @user, event: :authentication
-    flash[:success] = @user.sign_in_count == 1 ? (I18n.t 'devise.registrations.signed_up')
-                                               : (I18n.t 'devise.sessions.signed_in')
+    flash[:notice] = @user.sign_in_count == 1 ? (I18n.t 'devise.registrations.signed_up')
+                                              : (I18n.t 'devise.sessions.signed_in')
   end
 
   def failure

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,27 +1,24 @@
 header
   nav.navbar.navbar-expand-lg.navbar-light.bg-light
-    a#logo.navbar-brand[href=root_url]
-      | quasi case
+    = link_to "quasi case", root_path, class: "navbar-brand", id: "logo"
     button.navbar-toggler[type="button" data-toggle="collapse" data-target="#Navber" aria-controls="Navber" aria-expanded="false" aria-label="ナビゲーションの切替"]
       span.navbar-toggler-icon
     #Navber.collapse.navbar-collapse
       ul.navbar-nav.mr-auto
         li.nav-item.active
-          a.my-project.nav-link[href="#"]
-            | マイプロジェクト 
-            span.sr-only
-              | (現位置)
+          = link_to "マイプロジェクト", "#", class: "my-project nav-link"
+
         li.nav-item.dropdown
           a#navbarDropdown.nav-link.dropdown-toggle[href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"]
-            |  メニュー 
+            |  メニュー
           .dropdown-menu[aria-labelledby="navbarDropdown"]
-            a.dropdown-item[href="#"]
-              | メニュー1
-            a.dropdown-item[href="#"]
-              | メニュー2
+            = link_to "メニュー1", "#", class: "dropdown-item"
+            = link_to "メニュー2", "#", class: "dropdown-item"
             .dropdown-divider
-            a.dropdown-item[href=login_path]
-              | ログイン
+            - if user_signed_in?
+              = link_to "ログアウト", logout_path, class: "dropdown-item", method: :delete
+            - else
+              = link_to "ログイン", login_path, class: "dropdown-item"
       form.form-inline.my-2.my-lg-0
         input.form-control.mr-sm-2[type="search" placeholder="検索..." aria-label="検索..."]
         button.btn.btn-outline-success.my-2.my-sm-0[type="submit"]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,9 +9,7 @@ html
   body
     = render 'layouts/header'
     .container
-      p.notice
-        = notice
-      p.alert
-        = alert
+      - flash.each do |message_type, message|
+        div class=("alert alert-#{message_type}") = message
       = yield
       = debug(params) if Rails.env.development?

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,6 +10,8 @@ html
     = render 'layouts/header'
     .container
       - flash.each do |message_type, message|
+        - message_type = "info"   if message_type == "notice"
+        - message_type = "danger" if message_type == "alert"
         div class=("alert alert-#{message_type}") = message
       = yield
       = debug(params) if Rails.env.development?

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -11,4 +11,4 @@
       | ようこそ、
       = current_user.name
       | さん!
-    img[src=current_user.image]
+    = image_tag current_user.image

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -251,7 +251,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   devise_scope :user do
-    delete 'logout', to: 'devise/sessions#destroy'
+    get 'logout', to: 'devise/sessions#destroy'
   end
 end


### PR DESCRIPTION
#13 

新規登録とログインの時とで、別のフラッシュメッセージが出るようにしました。
ログインしている時と、ログアウトしている時とで、ヘッダーの表示が変わるようにしました。
ログアウト機能を実装しました。