### PR TITLE
form_withにlocal: trueオプションを追加

### DIFF
--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -3,7 +3,7 @@
     span#preview
     = image_tag @user.image, class: "rounded-circle mypage-image", id: "mypage-avator"
   .col-lg-6.mr-auto
-    = form_with model: @user do |f|
+    = form_with model: @user, local: true do |f|
       .form-group
           = f.label :name
           = f.text_field :name, value: @user.name, class: "form-control"


### PR DESCRIPTION
#26
マイページで、更新ボタンを押してもページがリダイレクト先へ飛ばなかったが、form_withにlocal: trueオプションを追加で解決。
下記を参考
https://qiita.com/bluegirl_beer/items/a361171f653edcd888ad