### PR TITLE
レビュー対応 E02-01、F01-01、F01-02

### DIFF
--- a/app/controllers/columns_controller.rb
+++ b/app/controllers/columns_controller.rb
@@ -29,8 +29,13 @@ class ColumnsController < ApplicationController
 
   def destroy
     if @column.destroy
-      # find reset_column_order at models/project.rb
-      @project.reset_column_order
+      # orderの値をリセット
+      @project.columns.order(order: :asc).each_with_index do |column, i|
+        unless column.update_attribute(:order, i)
+          render "columns#edit"
+        end
+      end
+
       redirect_to project_path(@project), notice: (I18n.t 'notice.destroy_column')
     else
       render :edit

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -2,6 +2,6 @@ class Card < ApplicationRecord
   belongs_to :project
   belongs_to :column
 
-  validates :name, presence: true, length: { maximum: 40 }
-  validates :name, uniqueness: {scope: [:project_id]}
+  validates :name, presence: true, length: { maximum: 40 },
+                   uniqueness: {scope: [:project_id]}
 end

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -1,8 +1,8 @@
 class Column < ApplicationRecord
   has_many :cards, dependent: :destroy
   belongs_to :project
-  validates :name, presence: true, length: { maximum: 40 }
-  validates :name, uniqueness: { scope: :project_id }
+  validates :name, presence: true, length: { maximum: 40 },
+                   uniqueness: { scope: :project_id }
 
   before_create do
     # orderに初期値を代入

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,12 +12,4 @@ class Project < ApplicationRecord
   def self.page_per(projects)
     projects.first_page? ? projects.per(FIRST_PAGE_PER) : projects.per(DEFAULT_PAGE_PER)
   end
-
-  def reset_column_order
-    self.columns.order(order: :asc).each_with_index do |column, i|
-      unless column.update_attribute(:order, i)
-        render "columns#edit"
-      end
-    end
-  end
 end

--- a/app/views/cards/_form.html.slim
+++ b/app/views/cards/_form.html.slim
@@ -19,7 +19,7 @@
             = f.select :assignee_id, [[current_user.name, current_user.id]], {}, {class: "form-control"}
           .form-group
             = f.submit submit_label, class: "btn btn-outline-dark btn-block mt-4"
-          - if title == "カードを編集"
+          - if project.persisted?
             .form-group
               = link_to "カードを削除", project_column_card_path(project, column, card),
                 method: :delete, data: { confirm: "本当にカードを削除しますか？" },

--- a/app/views/cards/edit.html.slim
+++ b/app/views/cards/edit.html.slim
@@ -1,2 +1,2 @@
-= render 'cards_form', card: @card, column: @column, project: @project,
+= render 'form', card: @card, column: @column, project: @project,
   title: "カードを編集", card_form_path: project_column_card_path, submit_label: "更新"

--- a/app/views/cards/new.html.slim
+++ b/app/views/cards/new.html.slim
@@ -1,2 +1,2 @@
-= render 'cards_form', project: @project, card: @card,
+= render 'form', project: @project, card: @card,
   title: "カードを作成", card_form_path: project_column_cards_path, submit_label: "作成"

--- a/app/views/columns/_form.html.slim
+++ b/app/views/columns/_form.html.slim
@@ -12,7 +12,7 @@
             = f.text_field :name, class: "form-control"
           .form-group
             = f.submit submit_label, class: "btn btn-outline-dark btn-block mt-4"
-          - if title == "カラムを編集"
+          - if project.persisted?
             .form-group
               = link_to "カラムを削除", project_column_path(project, column),
                 method: :delete, data: { confirm: "本当にカラムを削除しますか？" },

--- a/app/views/columns/edit.html.slim
+++ b/app/views/columns/edit.html.slim
@@ -1,1 +1,1 @@
-= render 'columns_form', column: @column, project: @project, title: "カラムを編集", column_form_path: project_column_path, submit_label: "更新"
+= render 'form', column: @column, project: @project, title: "カラムを編集", column_form_path: project_column_path, submit_label: "更新"

--- a/app/views/columns/new.html.slim
+++ b/app/views/columns/new.html.slim
@@ -1,1 +1,1 @@
-= render 'columns_form', column: @column, title: "カラムを作成", column_form_path: project_columns_path, submit_label: "作成"
+= render 'form', column: @column, title: "カラムを作成", column_form_path: project_columns_path, submit_label: "作成"


### PR DESCRIPTION
#58 

- E02-01
`app/models/project.rb`の`reset_column_order`メソッドをcolumns controllerへ戻す（renderメソッドがあるため）。
対象コミット：[afc1d70](https://github.com/ikedaCoffee/quasi-case-exam/commit/afc1d707be27d05c8e45e01944c3b355fccd2d4c)
**レビュー時の質問に対する回答は下記を参照してください。**
https://github.com/ikedaCoffee/quasi-case-exam/pull/53#pullrequestreview-118260358

- F01-01
同じカラムのバリデーションは1つにまとめる
対象コミット：[2919ef6](https://github.com/ikedaCoffee/quasi-case-exam/commit/2919ef6bb2893082b810042b3eee0cd22dd69f01)

- F01-02
パーシャルのファイル名を変更（`_cards_form.html.slim` => `_form.html.slim`）
newアクションかeditアクションかで条件分岐させる時は`persisted?`メソッドを使用
対象コミット：[b973344](https://github.com/ikedaCoffee/quasi-case-exam/commit/b9733447eb22961a2d8b5b738ad3dde321cec77b)